### PR TITLE
Fix boot from USB

### DIFF
--- a/scripts/astroberry-image-build.sh
+++ b/scripts/astroberry-image-build.sh
@@ -320,18 +320,25 @@ insmod png
 background_image /boot/grub/splash.png
 
 menuentry "Astroberry OS Live (64-bit)" {
-    search --set=root --file /live/filesystem.squashfs
     linux /live/vmlinuz boot=live components quiet splash noeject username=astroberry net.ifnames=0 biosdevname=0
     initrd /live/initrd
 }
 EOF
 
+    # Create the grub early stub config to find the right root folder
+    cat << EOF > iso/boot/grub/early-grub.cfg
+search --no-floppy --set=root --label "ASTROBERRY_OS"
+set prefix=($root)/boot/grub
+configfile $prefix/grub.cfg
+EOF
+
     # Create the EFI boot image
     truncate -s 10M iso/boot/grub/efi.img
     mkfs.vfat iso/boot/grub/efi.img
-    mmd -i iso/boot/grub/efi.img ::/EFI ::/EFI/boot
+    mmd -i iso/boot/grub/efi.img ::/EFI ::/EFI/boot ::/EFI/boot/grub
     mcopy -i iso/boot/grub/efi.img iso/EFI/boot/bootx64.efi ::/EFI/boot/
     mcopy -i iso/boot/grub/efi.img iso/EFI/boot/grubx64.efi ::/EFI/boot/
+    mcopy -i iso/boot/grub/efi.img iso/boot/grub/early-grub.cfg ::/EFI/boot/grub/grub.cfg
 
     # Create the el-torito image for legacy BIOS booting
     grub-mkimage -O i386-pc-eltorito \


### PR DESCRIPTION
When booting from USB, the signed grub efi executable has a hard time configuring the storage correctly.
An early config is needed that points grub to the right partition and loads the right configuration.
The config has then been adjusted to not search for the root fs again.
This now works with USB made with both dd and normal ISO procedures.
It does have a quirk with secure boot: depending on the firmware implementation of secure boot, the font cannot be read because of strict security policies, so the menu frame looks weird, there's no way around it that I can find. It does this with my virtualization software, which is qemu, but it works fine on a physical PC, so ymmv.