### PR TITLE
Change indi-3rdparty-drivers from Depends to Recommends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,13 +8,14 @@ Homepage: https://www.astroberry.io/
 
 Package: astroberry-os
 Architecture: arm64 amd64
-Depends: ${shlibs:Depends}, ${misc:Depends}, indi-3rdparty-drivers, gsc, astrometry.net,
+Depends: ${shlibs:Depends}, ${misc:Depends}, gsc, astrometry.net,
  xfce4, xfce4-goodies, xfce4-power-manager, xfce4-terminal, lightdm, dbus-x11,
  rpcc [arm64], rc-gui [arm64], piclone [arm64], firefox [arm64], firefox-esr [amd64],
  network-manager-applet, nm-connection-editor, synaptic,
  gpredict, ser-player, astap, siril, kstars-bleeding, phd2, phdlogview,
  firecapture, astrodmx-capture, ccdciel,
  astroberry-os-sysmod, astroberry-manager
+Recommends: indi-3rdparty-drivers
 Replaces: astroberry-os-lite (<< 3.2), astroberry-os-desktop (<< 3.2)
 Breaks: astroberry-os-lite (<< 3.2), astroberry-os-desktop (<< 3.2)
 Description: Astroberry OS is an operating system for Raspberry Pi for controlling astronomy equipment


### PR DESCRIPTION
This is the minimal change proposed in issue #106.

**What changed?**
- `indi-3rdparty-drivers` moved from `Depends:` to `Recommends:` in `debian/control`

**Why?**
- Default install still pulls all drivers (apt respects Recommends)
- Users who need individual drivers can `apt remove indi-3rdparty-drivers` without breaking the `astroberry-os` metapackage
- Enables mixing monolithic + individual driver installs from alternative APT sources

**Impact:**
- Zero risk — Recommends is the default policy for `apt-get install`
- Fully backward-compatible: existing installs see no change
- No changes to any other package, script, or configuration